### PR TITLE
Replicate the SystemVerilog testbench in cocotb

### DIFF
--- a/tb/testbench.py
+++ b/tb/testbench.py
@@ -10,70 +10,84 @@ from cocotb.runner import get_runner
 from cocotb.triggers import Timer, ClockCycles
 
 
+async def apply_sdr_inputs(I1, Q1, I2, Q2, dut):
+    """Apply the test stimuli to the sdr module."""
+    dut.ui_in.value = Q1 << 4 | I1
+    dut.uio_in.value = I2 << 4 | Q2
+    await ClockCycles(dut.clk, 1)
+
+
+async def sdr_test(dut):
+    """Execute the test for the sdr module."""
+    await apply_sdr_inputs(0, 2, 0, 2, dut)
+    await Timer(10, "ns")
+    await apply_sdr_inputs(0, 2, 0, 2, dut)
+    await Timer(10, "ns")
+    await apply_sdr_inputs(0, 2, 0, 2, dut)
+    await Timer(10, "ns")
+    await apply_sdr_inputs(0, 2, 0, 2, dut)
+    await Timer(80, "ns")
+    await apply_sdr_inputs(0, 2, 0, 2, dut)
+    await Timer(10, "ns")
+    await apply_sdr_inputs(0, 0, 0, 0, dut)
+
+    # Wait for the outputs to settle
+    await Timer(100, "ns")
+
+
 @cocotb.test()
-async def counter_test(dut):
-    """Testing the counter of the design."""
-    
+async def execute_sdr_test(dut):
+    """Execute the sdr test."""
+
     # Create a clock with a period of 10ns = 100MHz
-    clock = Clock(dut.clk, 10, 'ns')
+    clock = Clock(dut.clk, 10, "ns")
     await cocotb.start(clock.start())
 
-    dut.ena.value    = 1 # always 1
-    dut.ui_in.value  = 0
+    dut.ena.value = 1  # always 1
+    dut.ui_in.value = 0
     dut.uio_in.value = 0
 
-    # Reset the design for 100ns
+    # Reset pulse
     dut.rst_n.value = 0
-    await Timer(100, 'ns')
+    await Timer(10, "ns")
     dut.rst_n.value = 1
-    await Timer(100, 'ns')
 
-    # Ensure the otuput is 0x00
-    assert dut.uo_out.value == 0, "Output is not 0!"
+    await sdr_test(dut)
 
-    # Wait for 10 clock cycles
-    await ClockCycles(dut.clk, 10)
-    
-    # Ensure the otuput is still 0x00
-    assert dut.uo_out.value == 0, "Output is not 0!"
-    
-    # Enable the counter
-    dut.ui_in.value = 1
-    
-    # Wait for 10 clock cycles
-    await ClockCycles(dut.clk, 10)
-    
-    # Ensure the otuput is 10-1
-    assert dut.uo_out.value == 10-1, "Output is not 9!"
-    
-    # cocotb documentation: https://docs.cocotb.org/en/stable/refcard.html
-    # cocotb reference card: https://docs.cocotb.org/en/stable/refcard.html
 
 if __name__ == "__main__":
-
-    sim         = os.getenv("SIM", "icarus")
-    pdk_root    = os.getenv("PDK_ROOT", "~/.ciel")
-    pdk         = os.getenv("PDK", "ihp-sg13g2")
-    scl         = os.getenv("SCL", "sg13g2_stdcell")
-    gl          = os.getenv("GL", False)
+    sim = os.getenv("SIM", "icarus")
+    pdk_root = os.getenv("PDK_ROOT", "~/.ciel")
+    pdk = os.getenv("PDK", "ihp-sg13g2")
+    scl = os.getenv("SCL", "sg13g2_stdcell")
+    gl = os.getenv("GL", False)
 
     testbench_path = Path(__file__).resolve().parent
-    sources = []#[testbench_path / 'testbench.sv']
+    sources = []  # [testbench_path / 'testbench.sv']
     defines = {}
 
-    MACRO_NL = testbench_path / '../macro/nl/heichips25_template.nl.v'
+    MACRO_NL = testbench_path / "../macro/nl/heichips25_template.nl.v"
 
     if gl:
         if not MACRO_NL.exists():
-            print(f"The macro netlist {MACRO_NL} does not exist. Did you implement the macro?")
+            print(
+                f"The macro netlist {MACRO_NL} does not exist. Did you implement the macro?"
+            )
             sys.exit(0)
-    
-        sources.append(Path(pdk_root).expanduser() / pdk / "libs.ref" / scl / "verilog" / f"{scl}.v" )
+
+        sources.append(
+            Path(pdk_root).expanduser()
+            / pdk
+            / "libs.ref"
+            / scl
+            / "verilog"
+            / f"{scl}.v"
+        )
         sources.append(MACRO_NL)
-        defines = {'FUNCTIONAL': True, 'UNIT_DELAY': '#0'}
+        defines = {"FUNCTIONAL": True, "UNIT_DELAY": "#0"}
     else:
-        sources.extend(list(testbench_path.glob('../src/*')))
-        defines = {'RTL': True}
+        sources.extend(list(testbench_path.glob("../src/*")))
+        defines = {"RTL": True}
 
     hdl_toplevel = "heichips25_template"
 
@@ -82,15 +96,17 @@ if __name__ == "__main__":
         sources=sources,
         hdl_toplevel=hdl_toplevel,
         defines=defines,
-        timescale=['1ns', '1ps'],
+        timescale=["1ns", "1ps"],
         waves=True,
-        build_args=['--trace', '--trace-fst', '--trace-structs'] if sim == 'verilator' else ['-gno-specify'],
+        build_args=["--trace", "--trace-fst", "--trace-structs"]
+        if sim == "verilator"
+        else ["-gno-specify"],
     )
 
     runner.test(
         hdl_toplevel=hdl_toplevel,
-        test_module='testbench,',
-        timescale=['1ns', '1ps'],
+        test_module="testbench,",
+        timescale=["1ns", "1ps"],
         waves=True,
-        plusargs=['--trace-file', f'{hdl_toplevel}.fst']  if sim == 'verilator' else [],
+        plusargs=["--trace-file", f"{hdl_toplevel}.fst"] if sim == "verilator" else [],
     )


### PR DESCRIPTION
This should replicate the testbench which was created in SystemVerilog in cocotb in a way that allows the test to be imported by an external wrapper. Please check if the testbench implements the desired behavior and also check the resulting waveform.
You can run the test using `make sim` in the root of your repository and check the waveform using `gtkwave tb/sim_build/heichips25_template.fst` (both within the `nix-shell`).